### PR TITLE
[exp] Save Alert into DB

### DIFF
--- a/pkg/domain/interfaces/interfaces.go
+++ b/pkg/domain/interfaces/interfaces.go
@@ -47,6 +47,8 @@ type Database interface {
 	PutWorkflow(ctx *model.Context, workflow model.WorkflowRecord) error
 	GetWorkflows(ctx *model.Context, offset, limit int) ([]model.WorkflowRecord, error)
 	GetWorkflow(ctx *model.Context, id types.WorkflowID) (*model.WorkflowRecord, error)
+	PutAlert(ctx *model.Context, alert model.Alert) error
+	GetAlert(ctx *model.Context, id types.AlertID) (*model.Alert, error)
 	Lock(ctx *model.Context, ns types.Namespace, timeout time.Time) error
 	Unlock(ctx *model.Context, ns types.Namespace) error
 	Close() error

--- a/pkg/service/workflow.go
+++ b/pkg/service/workflow.go
@@ -72,6 +72,10 @@ func (x *WorkflowService) Create(ctx *model.Context, alert model.Alert) (*Workfl
 		namespace = (*string)(&alert.Namespace)
 	}
 
+	if err := x.db.PutAlert(ctx, alert); err != nil {
+		return nil, err
+	}
+
 	workflow := model.WorkflowRecord{
 		ID:        types.NewWorkflowID(),
 		CreatedAt: ctx.Now(),


### PR DESCRIPTION
This pull request introduces support for managing alerts in the database, including adding new methods to handle alerts and updating the associated tests. The most important changes include the addition of `PutAlert` and `GetAlert` methods, modifications to the `Client` struct to include alert collections, and updates to tests to cover alert functionality.

### Database Interface and Methods:

* Added `PutAlert` and `GetAlert` methods to the `Database` interface in `pkg/domain/interfaces/interfaces.go`.
* Implemented `PutAlert` and `GetAlert` methods in the Firestore client (`pkg/infra/firestore/client.go`).
* Implemented `PutAlert` and `GetAlert` methods in the in-memory client (`pkg/infra/memory/client.go`).

### Client Struct Modifications:

* Added `alertCollection` field to the Firestore client struct and initialized it in the `New` function (`pkg/infra/firestore/client.go`). [[1]](diffhunk://#diff-3e89659ce98dec11c6e02c25aae41fd297f53fea20aa5d81c87ac9d45d0a466cR29-R36) [[2]](diffhunk://#diff-3e89659ce98dec11c6e02c25aae41fd297f53fea20aa5d81c87ac9d45d0a466cR342)
* Added `alerts` map and `alertMutex` to the in-memory client struct (`pkg/infra/memory/client.go`).

### Test Updates:

* Modified environment variable for Firestore tests (`pkg/infra/database_test.go`).
* Added `testAlert` function and corresponding test case to validate alert functionality (`pkg/infra/database_test.go`). [[1]](diffhunk://#diff-173a7fcb220bc0f5b28e345ee01d906e9de86012f4b5d989681fb19f5dc7670cR55-R57) [[2]](diffhunk://#diff-173a7fcb220bc0f5b28e345ee01d906e9de86012f4b5d989681fb19f5dc7670cR251-R290)

### Service Modifications:

* Updated `Create` method in `WorkflowService` to save alerts (`pkg/service/workflow.go`).