### PR TITLE
Update cli command from "new" to "enhance" with Generative AI

### DIFF
--- a/pkg/controller/cli/cmd.go
+++ b/pkg/controller/cli/cmd.go
@@ -46,7 +46,7 @@ func New() *CLI {
 			cmdServe(),
 			cmdRun(),
 			cmdPlay(),
-			cmdNew(),
+			cmdEnhance(),
 			{
 				Name:    "version",
 				Aliases: []string{"v"},

--- a/pkg/controller/cli/enhance.go
+++ b/pkg/controller/cli/enhance.go
@@ -11,20 +11,20 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func cmdNew() *cli.Command {
+func cmdEnhance() *cli.Command {
 	return &cli.Command{
-		Name:    "new",
-		Aliases: []string{"n"},
-		Usage:   "Create new alertchain policy",
+		Name:    "enhance",
+		Aliases: []string{"e"},
+		Usage:   "Enhance alertchain policy with Generative AI",
 		Commands: []*cli.Command{
-			cmdNewIgnore(),
+			cmdEnhanceIgnore(),
 		},
 	}
 }
 
-func cmdNewIgnore() *cli.Command {
+func cmdEnhanceIgnore() *cli.Command {
 	var (
-		input           usecase.NewIgnorePolicyInput
+		input           usecase.EnhanceIgnorePolicyInput
 		alertIDSet      []string
 		geminiProjectID string
 		geminiLocation  string
@@ -111,7 +111,7 @@ func cmdNewIgnore() *cli.Command {
 			}
 			defer dbClose()
 
-			if err := usecase.NewIgnorePolicy(ctx, dbClient, geminiClient, input); err != nil {
+			if err := usecase.EnhanceIgnorePolicy(ctx, dbClient, geminiClient, input); err != nil {
 				return err
 			}
 

--- a/pkg/usecase/enhance_ignore.go
+++ b/pkg/usecase/enhance_ignore.go
@@ -50,7 +50,7 @@ func getRegoPackageName(policyData string) (string, error) {
 	return strings.Join(terms, "."), nil
 }
 
-type NewIgnorePolicyInput struct {
+type EnhanceIgnorePolicyInput struct {
 	AlertIDs         []types.AlertID
 	BasePolicyFile   string
 	TestDataDir      string
@@ -58,7 +58,7 @@ type NewIgnorePolicyInput struct {
 	OverWrite        bool
 }
 
-func (x NewIgnorePolicyInput) Validate() error {
+func (x EnhanceIgnorePolicyInput) Validate() error {
 	if len(x.AlertIDs) == 0 {
 		return goerr.New("AlertID is empty")
 	}
@@ -80,10 +80,10 @@ func (x NewIgnorePolicyInput) Validate() error {
 	return nil
 }
 
-func NewIgnorePolicy(ctx context.Context,
+func EnhanceIgnorePolicy(ctx context.Context,
 	dbClient interfaces.Database,
 	genAI interfaces.GenAI,
-	input NewIgnorePolicyInput,
+	input EnhanceIgnorePolicyInput,
 ) error {
 	if err := input.Validate(); err != nil {
 		return err

--- a/pkg/usecase/enhance_ignore_test.go
+++ b/pkg/usecase/enhance_ignore_test.go
@@ -18,7 +18,7 @@ import (
 //go:embed testdata/example_policy.rego
 var examplePolicy []byte
 
-func TestNewIgnorePolicy(t *testing.T) {
+func TestEnhanceIgnorePolicy(t *testing.T) {
 	ctx := context.Background()
 
 	alertID := types.AlertID("test-alert-id")
@@ -64,7 +64,7 @@ func TestNewIgnorePolicy(t *testing.T) {
 	// TODO: Enable this line
 	// defer os.RemoveAll(input.TestDataDir)
 
-	input := usecase.NewIgnorePolicyInput{
+	input := usecase.EnhanceIgnorePolicyInput{
 		AlertIDs:         []types.AlertID{alertID},
 		BasePolicyFile:   fd.Name(),
 		TestDataDir:      dir,
@@ -72,7 +72,7 @@ func TestNewIgnorePolicy(t *testing.T) {
 		OverWrite:        true,
 	}
 
-	gt.NoError(t, usecase.NewIgnorePolicy(ctx, dbClient, genAI, input))
+	gt.NoError(t, usecase.EnhanceIgnorePolicy(ctx, dbClient, genAI, input))
 
 	// Check if test data file is created
 	testDataPath := filepath.Join(input.TestDataDir, slug, "data.json")


### PR DESCRIPTION
This pull request includes significant changes to the CLI commands and the underlying use case implementations. The primary change is the renaming and enhancement of the `cmdNew` command to `cmdEnhance`, along with the associated input structures and methods.

Key changes include:

### CLI Command Changes:
* [`pkg/controller/cli/cmd.go`](diffhunk://#diff-19dab9e829480b796def9676391def4e24308a9ef3bb911f8c57bf8ac30ea01cL49-R49): The `cmdNew` command has been replaced with `cmdEnhance` in the CLI initialization.
* [`pkg/controller/cli/enhance.go`](diffhunk://#diff-4b491314cce1ed1da422c87289c5a0990e68ae8c351823fcc551c9d27a1eef84L14-R27): The file has been renamed from `new.go` to `enhance.go`, and the `cmdNew` command and related methods have been updated to `cmdEnhance`. [[1]](diffhunk://#diff-4b491314cce1ed1da422c87289c5a0990e68ae8c351823fcc551c9d27a1eef84L14-R27) [[2]](diffhunk://#diff-4b491314cce1ed1da422c87289c5a0990e68ae8c351823fcc551c9d27a1eef84L114-R114)

### Use Case Changes:
* [`pkg/usecase/enhance_ignore.go`](diffhunk://#diff-c2fe491ad32193a2ad779065057a6bb5a56d9a143e5a82e4c389fcb1fc6af5afL53-R61): The file has been renamed from `new_ignore.go` to `enhance_ignore.go`, and the `NewIgnorePolicyInput` structure and related methods have been updated to `EnhanceIgnorePolicyInput`. [[1]](diffhunk://#diff-c2fe491ad32193a2ad779065057a6bb5a56d9a143e5a82e4c389fcb1fc6af5afL53-R61) [[2]](diffhunk://#diff-c2fe491ad32193a2ad779065057a6bb5a56d9a143e5a82e4c389fcb1fc6af5afL83-R86)

### Test Changes:
* [`pkg/usecase/enhance_ignore_test.go`](diffhunk://#diff-bef4e72b698d3dcd2b20f05d5885953857e034c78768d064cdb51c2bdb24756bL21-R21): The file has been renamed from `new_ignore_test.go` to `enhance_ignore_test.go`, and the test functions have been updated accordingly. [[1]](diffhunk://#diff-bef4e72b698d3dcd2b20f05d5885953857e034c78768d064cdb51c2bdb24756bL21-R21) [[2]](diffhunk://#diff-bef4e72b698d3dcd2b20f05d5885953857e034c78768d064cdb51c2bdb24756bL67-R75)